### PR TITLE
Add Claude Code project config and caveman-commit skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "markdown-editor@gilbertotcc-claude-plugins": true
+  }
+}

--- a/.claude/skills/caveman-commit/README.md
+++ b/.claude/skills/caveman-commit/README.md
@@ -1,0 +1,44 @@
+# caveman-commit
+
+Terse Conventional Commits. Why over what.
+
+## What it does
+
+Generates commit messages in Conventional Commits format. Subject ≤50 chars, hard cap 72. Imperative mood. Body only when the *why* is non-obvious or there are breaking changes. No AI attribution, no "this commit does X", no emoji unless the project uses them. Body always required for breaking changes, security fixes, data migrations, and reverts — future debuggers need the context.
+
+Outputs only the message. Does not stage, commit, or amend.
+
+## How to invoke
+
+```
+/caveman-commit
+```
+
+Also triggers on phrases like "write a commit", "commit message", "generate commit".
+
+## Example output
+
+Diff: new endpoint for user profile.
+
+```
+feat(api): add GET /users/:id/profile
+
+Mobile client needs profile data without the full user payload
+to reduce LTE bandwidth on cold-launch screens.
+
+Closes #128
+```
+
+Diff: breaking API rename.
+
+```
+feat(api)!: rename /v1/orders to /v1/checkout
+
+BREAKING CHANGE: clients on /v1/orders must migrate to /v1/checkout
+before 2026-06-01. Old route returns 410 after that date.
+```
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full LLM-facing instructions
+- [Caveman README](../../README.md) — repo overview

--- a/.claude/skills/caveman-commit/SKILL.md
+++ b/.claude/skills/caveman-commit/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: caveman-commit
+description: >
+  Ultra-compressed commit message generator. Cuts noise from commit messages while preserving
+  intent and reasoning. Conventional Commits format. Subject ≤50 chars, body only when "why"
+  isn't obvious. Use when user says "write a commit", "commit message", "generate commit",
+  "/commit", or invokes /caveman-commit. Auto-triggers when staging changes.
+---
+
+Write commit messages terse and exact. Conventional Commits format. No fluff. Why over what.
+
+## Rules
+
+**Subject line:**
+- `<type>(<scope>): <imperative summary>` — `<scope>` optional
+- Types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`, `style`, `revert`
+- Imperative mood: "add", "fix", "remove" — not "added", "adds", "adding"
+- ≤50 chars when possible, hard cap 72
+- No trailing period
+- Match project convention for capitalization after the colon
+
+**Body (only if needed):**
+- Skip entirely when subject is self-explanatory
+- Add body only for: non-obvious *why*, breaking changes, migration notes, linked issues
+- Wrap at 72 chars
+- Bullets `-` not `*`
+- Reference issues/PRs at end: `Closes #42`, `Refs #17`
+
+**What NEVER goes in:**
+- "This commit does X", "I", "we", "now", "currently" — the diff says what
+- "As requested by..." — use Co-authored-by trailer
+- "Generated with Claude Code" or any AI attribution — unless the user's own rule requires an `Assisted-by`/AI-attribution trailer, then add it as a trailer
+- Emoji (unless project convention requires)
+- Restating the file name when scope already says it
+
+## Examples
+
+Diff: new endpoint for user profile with body explaining the why
+- ❌ "feat: add a new endpoint to get user profile information from the database"
+- ✅
+  ```
+  feat(api): add GET /users/:id/profile
+
+  Mobile client needs profile data without the full user payload
+  to reduce LTE bandwidth on cold-launch screens.
+
+  Closes #128
+  ```
+
+Diff: breaking API change
+- ✅
+  ```
+  feat(api)!: rename /v1/orders to /v1/checkout
+
+  BREAKING CHANGE: clients on /v1/orders must migrate to /v1/checkout
+  before 2026-06-01. Old route returns 410 after that date.
+  ```
+
+## Auto-Clarity
+
+Always include body for: breaking changes, security fixes, data migrations, anything reverting a prior commit. Never compress these into subject-only — future debuggers need the context.
+
+## Boundaries
+
+Only generates the commit message. Does not run `git commit`, does not stage files, does not amend. Output the message as a code block ready to paste. "stop caveman-commit" or "normal mode": revert to verbose commit style.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/settings.local.json

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,6 +13,8 @@ config:
 
 globs:
   - "**/*.md"
+ignores:
+  - .claude/skills/caveman-commit/*
 
 fix: true
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## What this is
+
+Ansible repository that configures a personal single-node Kubernetes cluster
+(powered by [k3s](https://k3s.io/)) on a Raspberry Pi 4 running Debian stable.
+Forked from [iamleot/rpi-ansible](https://github.com/iamleot/rpi-ansible).
+There is exactly one target host, defined in `hosts.ini`, connected to as
+`root` (see `ansible.cfg`).
+
+## Commands
+
+All common tasks are wired through [Task](https://taskfile.dev/) (`Taskfile.yml`):
+
+```sh
+task check          # runs yamllint + syntax-check + ansible-lint (the full CI gate)
+task yamllint       # yamllint . 
+task syntax-check   # ansible-playbook --syntax-check against playbook.yml
+task ansible-lint   # ansible-lint
+task run            # ansible-playbook --verbose playbook.yml (applies config to the real RPI)
+```
+
+Run `task check` before considering any change to `playbook.yml`, `tasks/*.yml`,
+or lint configs complete — this is exactly what the `ansible.yaml` CI workflow runs.
+
+There is no test suite; correctness is validated via syntax-check + ansible-lint
+(structural/style) and via `conftest` in CI (policy checks against
+`.github` using an external policy bundle, see `.github/workflows/conftest.yaml`).
+
+## Architecture
+
+- `playbook.yml` is the single entrypoint. It targets `hosts: all` and imports
+  task files from `tasks/` **in a fixed order**, each responsible for one
+  concern:
+  1. `tasks/update_packages.yml` — apt upgrade everything
+  2. `tasks/packages.yml` — install the fixed package list
+  3. `tasks/network.yml` — set hostname from `files/hostname`
+  4. `tasks/wireguard.yml` — install WireGuard, generate keys idempotently (uses
+     `creates:` guards)
+  5. `tasks/dns_resolver.yml` — install/enable `unbound`, point
+     `/etc/resolv.conf` at it
+  6. `tasks/k3s.yml` — install/upgrade k3s to the version pinned by
+     `k3s_version` in `playbook.yml`, using `files/k3s-config.yaml`
+- Order matters: later task files assume earlier ones already ran (packages
+  installed, hostname set, etc.). When adding a new concern, add a new
+  `tasks/<name>.yml` file and import it from `playbook.yml` in the appropriate
+  position rather than growing an existing task file with unrelated work.
+- `files/` holds static files pushed verbatim to the Pi via `ansible.builtin.copy`
+  (hostname, k3s config, resolv.conf). WiFi credentials are deliberately
+  **not** managed here — see the "Manual configurations" section of
+  `README.md` — to avoid committing secrets.
+- `k3s_version` (in `playbook.yml`) is validated by an `assert` in
+  `tasks/k3s.yml` against `v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+`; the task
+  compares the installed version to it and only reinstalls on mismatch. Bump
+  this var to upgrade k3s; valid channel/version values are listed at
+  <https://update.k3s.io/v1-release/channels>.
+- Nearly every task uses `become: true` and guards apt cache updates with
+  `cache_valid_time: 3600`, following the existing pattern for any new apt-based
+  task.
+
+## CI (GitHub Actions, all under `.github/workflows/`)
+
+- `ansible.yaml` — runs `task check` on push to `main` and on PRs.
+- `conftest.yaml` — runs `conftest` against `.github` using an external,
+  personal policy bundle (`iamleot/conftest-policies`), on push to `main` and PRs.
+- `check-markdown-files.yml` — `markdownlint-cli2` + `lychee` link checking,
+  scoped to `**.md` changes.
+- Dependency updates are handled by both Dependabot (`.github/dependabot.yml`,
+  GitHub Actions only) and Renovate (`renovate.json`, which also has custom
+  regex managers to track `CONFTEST_VERSION` / `TASK_VERSION` pins inside the
+  workflow YAML files).
+
+## Conventions worth preserving
+
+- Every task in `tasks/*.yml` has a trailing-period, capitalized `name:`
+  (e.g. `Install unbound if needed.`) — match this style for new tasks.
+  Every task file starts with a `---` and a short `#`-comment block describing
+  its purpose.
+  Idempotency-sensitive shell steps use `creates:` / `changed_when:` rather than
+  free-running shell commands.
+- Markdown must pass `markdownlint-cli2` (`.markdownlint-cli2.yaml`: ATX
+  headers, 80-char line length except in tables/code blocks) and `lychee`
+  link checking (add unreachable/intentional URLs to `.lycheeignore` rather
+  than disabling the check).

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "caveman-commit": {
+      "source": "juliusbrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-commit/SKILL.md",
+      "computedHash": "790a4eeace0be35c6691faf923518ba5bd50f1f1305d1101d09dd4971be94e00"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project guidance for Claude Code
- Add `.claude/` settings and the `caveman-commit` skill (tracked via `skills-lock.json`)
- Exclude the caveman-commit skill's README from markdownlint since it doesn't follow this repo's style rules

## Test plan
- [x] `task check` (markdownlint, syntax-check, ansible-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)