### PR TITLE
Reconcile package list and add apt cleanup before upgrades

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -14,6 +14,7 @@
     name:
       - bash-completion
       - curl
+      - htop
       - linux-cpupower
       - python3
       - tcpdump

--- a/tasks/update_packages.yml
+++ b/tasks/update_packages.yml
@@ -3,8 +3,8 @@
 # Update all packages to latest version.
 #
 # Uses apt and update the apt cache and keep it for 3600 seconds (to possibly
-# save some bandwidth and time) and update all packages to their latest
-# version.
+# save some bandwidth and time), clean up old package files and unused
+# dependencies, and update all packages to their latest version.
 #
 
 - name: Update apt cache if needed.
@@ -12,6 +12,14 @@
   ansible.builtin.apt:
     cache_valid_time: 3600
     update_cache: true
+- name: Autoclean apt cache.
+  become: true
+  ansible.builtin.apt:
+    autoclean: true
+- name: Autoremove unused packages.
+  become: true
+  ansible.builtin.apt:
+    autoremove: true
 - name: Update all packages to latest version.
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary
- Add `htop` to the base package set for headless CPU/thermal-throttle diagnosis, and confirm the rest of the fork's ops-tooling package list is deliberate (not upstream drift)
- Run `apt autoclean` + `apt autoremove` before the "upgrade everything" step in `tasks/update_packages.yml`, clearing old kernel packages before the new one lands — mirrors upstream's fix for the `/boot/firmware`-fills-up incident (iamleot/rpi-ansible#75)

Closes #13, closes #14, closes #16.

## Test plan
- [x] `task check` (yamllint + `ansible-playbook --syntax-check` + `ansible-lint`) passes
- [x] Apply to the live Pi via `task run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)