### PR TITLE
roles/k3s: cap containerd/kubelet container log rotation

### DIFF
--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 k3s_tls_san:
   - 10.254.10.8
+k3s_kubelet_container_log_max_size: 10Mi
+k3s_kubelet_container_log_max_files: 3

--- a/roles/k3s/handlers/main.yml
+++ b/roles/k3s/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+#
+# Handlers for k3s.
+#
+
+- name: Restart k3s.
+  become: true
+  ansible.builtin.service:
+    name: k3s
+    state: restarted

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -39,6 +39,7 @@
     group: root
     directory_mode: '0755'
     mode: '0644'
+  notify: Restart k3s.
 - name: Get k3s version if installed.
   become: true
   ansible.builtin.shell:

--- a/roles/k3s/templates/k3s-config.yaml.j2
+++ b/roles/k3s/templates/k3s-config.yaml.j2
@@ -5,3 +5,6 @@ tls-san:
 {% endfor %}
 disable: metrics-server,traefik
 disable-cloud-controller: true
+kubelet-arg:
+  - "container-log-max-size={{ k3s_kubelet_container_log_max_size }}"
+  - "container-log-max-files={{ k3s_kubelet_container_log_max_files }}"


### PR DESCRIPTION
## Summary

- Container stdout/stderr logs under `/var/log/pods` (managed by k3s's
  embedded kubelet) had no size or file-count limit, making them the
  largest unbounded-write source on the board — an ongoing write-wear
  contributor on the microSD.
- Adds `k3s_kubelet_container_log_max_size` (`10Mi`) and
  `k3s_kubelet_container_log_max_files` (`3`) to
  `roles/k3s/defaults/main.yml`, and renders them as a `kubelet-arg:`
  block in `roles/k3s/templates/k3s-config.yaml.j2`, which k3s forwards
  verbatim to its embedded kubelet — no new role or separate
  kubelet/containerd config file needed.
- `10Mi` × 3 files bounds worst-case log residency to 30Mi/container,
  close to upstream kubelet defaults (10Mi/5 files), tightened on file
  count given the SD-wear concern.
- Adds `roles/k3s/handlers/main.yml` (`Restart k3s.`), notified by the
  "Populate k3s configuration" task in `roles/k3s/tasks/main.yml`.
  Without it, a config-only change (no `k3s_version` bump) would
  template a new `/etc/rancher/k3s/config.yaml` but never restart the
  running k3s process, since only a version mismatch triggers a
  restart (via the install script). Caught this during live
  verification: `make run` reported the config task as `changed`, but
  the live kubelet's `configz` still showed no
  `containerLogMaxSize`/`containerLogMaxFiles` until k3s was restarted
  by hand.

## Test plan

- [x] `make check` (yamllint + syntax-check; ansible-lint requires an
      interactive vault unlock in this environment, not run here).
- [x] Applied to the live board via `make run`.
- [x] Confirmed via `/etc/rancher/k3s/config.yaml` containing the new
      `kubelet-arg` entries.
- [x] Confirmed the *running* kubelet picked up the change (not just
      the file) via its `configz` endpoint:
      `containerLogMaxSize: 10Mi`, `containerLogMaxFiles: 3`.
- [x] `systemctl status k3s` healthy after restart; node `Ready`, all
      pods `Running`.

Closes #38