### PR TITLE
Add roles/journald: cap journald disk usage on the microSD

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -9,6 +9,7 @@
 
   roles:
     - role: packages
+    - role: journald
     - role: network
     - role: wireless
     - role: dns_resolver

--- a/roles/journald/defaults/main.yml
+++ b/roles/journald/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+journald_system_max_use: 50M
+journald_system_max_file_size: 8M
+journald_max_retention: 1month

--- a/roles/journald/handlers/main.yml
+++ b/roles/journald/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart systemd-journald.
+  become: true
+  ansible.builtin.service:
+    name: systemd-journald
+    state: restarted

--- a/roles/journald/meta/main.yml
+++ b/roles/journald/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/roles/journald/tasks/main.yml
+++ b/roles/journald/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+#
+# Cap journald's on-disk footprint.
+#
+# Template journald.conf with explicit size/retention caps so systemd
+# journal logs don't grow unbounded on the microSD.
+#
+
+- name: Template journald.conf with size/retention caps.
+  become: true
+  ansible.builtin.template:
+    src: journald.conf.j2
+    dest: /etc/systemd/journald.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart systemd-journald.

--- a/roles/journald/templates/journald.conf.j2
+++ b/roles/journald/templates/journald.conf.j2
@@ -1,0 +1,4 @@
+[Journal]
+SystemMaxUse={{ journald_system_max_use }}
+SystemMaxFileSize={{ journald_system_max_file_size }}
+MaxRetentionSec={{ journald_max_retention }}


### PR DESCRIPTION
## Summary

- `journald.conf` had no size/retention caps anywhere, so journal files grew unbounded on the microSD (333.6M and rising, no ceiling) — extra continuous write volume on flash storage already under write-endurance pressure from k3s/containerd.
- Adds a new `roles/journald` role, mirroring how `roles/dns_resolver` is split out from `roles/network`: it templates `/etc/systemd/journald.conf` with `SystemMaxUse=50M`, `SystemMaxFileSize=8M`, `MaxRetentionSec=1month`, restarting `systemd-journald` via a handler on change.
- Positioned right after `roles/packages` in `playbook.yml`'s `roles:` list, so uncapped logging doesn't run any longer than necessary during a fresh provision.

Closes #37

## Test plan

- [x] `make check` (yamllint + syntax-check + ansible-lint) passes clean.
- [x] Applied to the live board via `make run`: `journalctl --disk-usage` dropped from 333.6M to 21.1M, `systemctl status systemd-journald` healthy post-restart.
- [x] Re-ran `make run` twice more: the journald task reports `changed: false` and a full re-run shows `changed=0` across the whole play (idempotent).