### PR TITLE
Add roles/zram: zram-backed swap for OOM headroom

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -10,6 +10,7 @@
   roles:
     - role: packages
     - role: journald
+    - role: zram
     - role: network
     - role: wireless
     - role: dns_resolver

--- a/roles/zram/defaults/main.yml
+++ b/roles/zram/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+zram_fraction: 2
+zram_max_size_mb: 4096

--- a/roles/zram/handlers/main.yml
+++ b/roles/zram/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart zram swap.
+  become: true
+  ansible.builtin.systemd:
+    name: systemd-zram-setup@zram0.service
+    daemon_reload: true
+    state: restarted

--- a/roles/zram/meta/main.yml
+++ b/roles/zram/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+#
+# Configure zram-backed swap via systemd-zram-generator, so this low-RAM
+# board has memory headroom under pressure without writing swap to the
+# microSD, since zram lives entirely in compressed RAM.
+#
+
+- name: Update apt cache if needed.
+  become: true
+  ansible.builtin.apt:
+    cache_valid_time: 3600
+    update_cache: true
+- name: Install systemd-zram-generator if needed.
+  become: true
+  ansible.builtin.apt:
+    name: systemd-zram-generator
+    state: present
+- name: Populate zram-generator configuration.
+  become: true
+  ansible.builtin.template:
+    src: zram-generator.conf.j2
+    dest: /etc/systemd/zram-generator.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart zram swap.

--- a/roles/zram/templates/zram-generator.conf.j2
+++ b/roles/zram/templates/zram-generator.conf.j2
@@ -1,0 +1,2 @@
+[zram0]
+zram-size = min(ram / {{ zram_fraction }}, {{ zram_max_size_mb }})


### PR DESCRIPTION
## Summary

- Adds `roles/zram`, installing and configuring `systemd-zram-generator` so the board has zram-backed swap instead of none at all.
- Sizes the device via `zram-size = min(ram / 2, 4096)` (the package's own default, ~1.85GiB on this 3.7GiB board) — the current, non-deprecated `zram-generator.conf` key, verified against Debian trixie's manpages.
- Config changes are applied without a reboot via a handler that does `daemon_reload` + restart of `systemd-zram-setup@zram0.service`, per Debian's documented procedure.
- Role placed right after `packages` in `playbook.yml`, before anything else that could pressure memory.

Closes #40

## Test plan

- [x] `make yamllint` passes
- [x] `make syntax-check` passes
- [x] `ansible-lint roles/zram` passes (isolated — `make ansible-lint` locally fails on unrelated pre-existing vault-password/gpg environment issue, reproduced identically on a clean checkout of this branch before these changes; CI has no vault password configured so it isn't affected)
- [x] Apply to the live board (`make run`) and confirm via `swapon --show` and `systemctl status systemd-zram-setup@zram0.service` — 1.8GiB `/dev/zram0` swap active, `systemd-zram-setup@zram0.service` and `dev-zram0.swap` both `active`
- [x] Confirm a second `make run` shows no changes (idempotency) — second run: `ok=30 changed=0 unreachable=0 failed=0`
