### PR TITLE
docs: point microSD card image source at cloud.debian.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,30 @@ configure it.
 ### Prepare the microSD card
 
 Debian GNU/Linux images for Raspberry Pis are available at
-<https://raspi.debian.net/daily-images/>.
+<https://cloud.debian.org/images/cloud/trixie/daily/latest/>.
 
 For RPI4, you can download it with:
 
 ```sh
-curl -OL 'https://raspi.debian.net/daily/raspi_4_bookworm.img.xz'
-curl -OL 'https://raspi.debian.net/daily/raspi_4_bookworm.img.xz.sha256'
+curl -OL 'https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-raspi-arm64-daily.tar.xz'
+curl -OL 'https://cloud.debian.org/images/cloud/trixie/daily/latest/SHA512SUMS'
+```
+
+The download is a `.tar.xz` archive wrapping a single raw disk image
+(`disk.raw`); extract it before writing to a microSD card:
+
+```sh
+tar xf debian-13-raspi-arm64-daily.tar.xz
 ```
 
 Then, write the image to a microSD card.
 
-> :information_source: The example below is based on an `xzcat` run on NetBSD,
+> :information_source: The example below is based on a `dd` run on NetBSD,
 > where `sd0` corresponds to the microSD card.
 > You can use equivalent commands on other OSes.
 
 ```sh
-xzcat raspi_4_bookworm.img.xz | dd of=/dev/rsd0 bs=1m
+dd if=disk.raw of=/dev/rsd0 bs=1m
 ```
 
 ### Your first run


### PR DESCRIPTION
## Summary

- `raspi.debian.net` has posted a deprecation banner (live since
  2026-01-28) pointing visitors at the official Debian Cloud Images
  project (`cloud.debian.org`) instead. Updates the "Prepare the
  microSD card" section in `README.md` to download from
  `cloud.debian.org`.
- Fixes the stale `bookworm` reference to `trixie` (current Debian
  stable, matching what the board actually runs).
- Accounts for the format change: the new source ships a
  `.tar.xz`-wrapped raw disk image (`disk.raw`) rather than a bare
  `.img.xz`, so the doc now shows a `tar xf` extraction step before
  writing the card, and the `dd` step writes `disk.raw` directly
  (no more `xzcat` piping).

## Verification

- Downloaded `debian-13-raspi-arm64-daily.tar.xz` from
  `cloud.debian.org` and confirmed its SHA512 matches the published
  `SHA512SUMS` entry.
- Inspected the tarball's contents (`tar tvf`) and confirmed it
  contains exactly one member, `disk.raw`, matching the doc's new
  extraction step.
- `make check` passes.
- `markdownlint-cli2` reports 0 issues on `README.md`.
- `lychee` against `README.md` passes (0 errors) across several
  repeated runs.
- **Not verified**: actually `dd`-ing `disk.raw` to a physical
  microSD card and booting it. The board this repo manages was
  already provisioned before the `raspi.debian.net` deprecation was
  discovered, so the download/checksum/extract steps were tested
  live but the final flash-and-boot step wasn't re-exercised on
  real hardware.

Closes #36