### PR TITLE
roles/k3s: pin kubelet resolv-conf to stop DNS search-domain poisoning

### DIFF
--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -3,3 +3,11 @@ k3s_tls_san:
   - 10.254.10.8
 k3s_kubelet_container_log_max_size: 10Mi
 k3s_kubelet_container_log_max_files: 3
+# Public, non-loopback resolvers for kubelet's --resolv-conf override (see
+# roles/k3s/tasks/main.yml). k3s cannot use the host's own /etc/resolv.conf
+# (127.0.0.1, see roles/dns_resolver) for pods, and its auto-detected
+# fallback can pick up the LAN router's DNS and DHCP search domain, which
+# leaks into every pod's resolver search path. Pin it explicitly instead.
+k3s_kubelet_resolv_conf_nameservers:
+  - 1.1.1.1
+  - 9.9.9.9

--- a/roles/k3s/tasks/main.yml
+++ b/roles/k3s/tasks/main.yml
@@ -30,6 +30,15 @@
     owner: root
     group: root
     mode: '0755'
+- name: Populate kubelet resolv.conf override.
+  become: true
+  ansible.builtin.template:
+    src: resolv.conf.j2
+    dest: /etc/rancher/k3s/resolv.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart k3s.
 - name: Populate k3s configuration.
   become: true
   ansible.builtin.template:

--- a/roles/k3s/templates/k3s-config.yaml.j2
+++ b/roles/k3s/templates/k3s-config.yaml.j2
@@ -8,3 +8,4 @@ disable-cloud-controller: true
 kubelet-arg:
   - "container-log-max-size={{ k3s_kubelet_container_log_max_size }}"
   - "container-log-max-files={{ k3s_kubelet_container_log_max_files }}"
+  - "resolv-conf=/etc/rancher/k3s/resolv.conf"

--- a/roles/k3s/templates/resolv.conf.j2
+++ b/roles/k3s/templates/resolv.conf.j2
@@ -1,0 +1,3 @@
+{% for nameserver in k3s_kubelet_resolv_conf_nameservers %}
+nameserver {{ nameserver }}
+{% endfor %}


### PR DESCRIPTION
## Summary

Flux's `source-controller` on `rpi-202508` was intermittently (and, for
`GitRepository`, consistently) failing to reach `github.com` and other
external hosts, with `dial tcp 127.0.0.1:<port>: connect: connection
refused`.

Root cause, confirmed live via `tcpdump` while forcing a Flux
reconcile: CoreDNS's actual upstream forward target was the LAN
router (`192.168.1.1`), with the ISP's DHCP search domain
(`homenet.telecomitalia.it`) leaked into pods' `resolv.conf`. Because
pods use `ndots:5`, a short external name like `github.com` gets tried
against that search domain *before* the bare name
(`github.com.homenet.telecomitalia.it`). The router answers that
made-up name with a wildcard `A 127.0.0.1` instead of `NXDOMAIN`,
CoreDNS caches it, and clients dial the loopback address instead of
GitHub.

The host's own `/etc/resolv.conf` (`nameserver 127.0.0.1`, via
`roles/dns_resolver`/unbound) is not directly usable by pods, so k3s
auto-detects a "real" upstream for kubelet — and that auto-detection
is what picked up the router and its search domain in this case.

- Not a `systemd-resolved` issue (confirmed inactive on this host).
- Not a dead network link, GitHub outage, or credentials problem —
  ruled out per the original bug report.

## Change

Pin kubelet's `--resolv-conf` to a static file with public resolvers
and **no search domain**, so this auto-detection can no longer pick up
the LAN router or leak its search domain into pods (including CoreDNS
itself, which also uses this file via its `dnsPolicy: Default`):

- `roles/k3s/templates/resolv.conf.j2` (new) — renders
  `k3s_kubelet_resolv_conf_nameservers` (defaults to `1.1.1.1`,
  `9.9.9.9`).
- `roles/k3s/tasks/main.yml` — templates it to
  `/etc/rancher/k3s/resolv.conf`, notifies `Restart k3s.`.
- `roles/k3s/templates/k3s-config.yaml.j2` — adds
  `kubelet-arg: resolv-conf=/etc/rancher/k3s/resolv.conf`.
- `roles/k3s/defaults/main.yml` — new
  `k3s_kubelet_resolv_conf_nameservers` var.

## Test plan

- [x] `make yamllint`
- [x] `make syntax-check`
- [x] `make ansible-lint`
- [x] `make run` against `rpi-202508`, then confirm
      `kubectl logs -n flux-system deploy/source-controller -f` stops
      showing `dial tcp 127.0.0.1` and `kubectl get gitrepository -n
      flux-system flux-system` reaches current `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)