### PR TITLE
Fix wlan0: use static IP instead of DHCP

### DIFF
--- a/roles/wireless/templates/wlan0.j2
+++ b/roles/wireless/templates/wlan0.j2
@@ -1,4 +1,6 @@
 allow-hotplug wlan0
-iface wlan0 inet dhcp
+iface wlan0 inet static
+    address 192.168.1.25/27
+    gateway 192.168.1.1
     wpa-ssid {{ wireless_ssid }}
     wpa-psk {{ wireless_psk }}


### PR DESCRIPTION
## Summary
- wlan0 always got the same DHCP-assigned address (router binds it to the MAC), but the DHCP client kept rewriting `/etc/resolv.conf` with the ISP's DNS servers, clobbering the resolvconf setup k3s relies on and breaking DNS resolution for containers
- Discovered when Flux CD stopped reconciling because it could not resolve github.com
- Switch `roles/wireless/templates/wlan0.j2` to a static IP configuration so the DHCP client no longer touches resolv.conf

## Test plan
- [x] `make check`
- [x] `make run` against the Pi and confirm wlan0 comes up with the static address
- [x] Confirm containers in k3s can resolve external domains and Flux CD reconciles again