### PR TITLE
Add package `bind9-dnsutils`

### DIFF
--- a/roles/packages/defaults/main.yml
+++ b/roles/packages/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 packages_needed_packages:
   - bash-completion
+  - bind9-dnsutils
   - curl
   - htop
   - linux-cpupower


### PR DESCRIPTION
Add `bind9-dnsutils` that provides `dig`. `dig` tool was used to diagnose the issue with DNS resolving fixed in commit 972c04d.