### PR TITLE
Add `python-is-python3`

### DIFF
--- a/roles/packages/defaults/main.yml
+++ b/roles/packages/defaults/main.yml
@@ -5,6 +5,7 @@ packages_needed_packages:
   - curl
   - htop
   - linux-cpupower
+  - python-is-python3
   - python3
   - tcpdump
   - tmux


### PR DESCRIPTION
Add the package `python-is-python3` that allows running Python scripts that require `python` command.