### PR TITLE
feat(monitoring): expose RPi3 host metrics via Prometheus Node Exporter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,17 +8,20 @@ code in this repository.
 Ansible repository that configures personal Raspberry Pi boards on
 Debian stable: a Raspberry Pi 4 (RPi4), plus a Raspberry Pi 3 (RPi3) as
 a second, lighter-weight board. RPi4 also runs a single-node Kubernetes
-cluster powered by [k3s](https://k3s.io/). Forked from
+cluster powered by [k3s](https://k3s.io/); RPi3 instead runs Prometheus
+Node Exporter, exposing host metrics for the RPi4/Flux-managed
+Prometheus to scrape. Forked from
 [iamleot/rpi-ansible](https://github.com/iamleot/rpi-ansible).
 `hosts.ini` defines two groups — `rpi4` and `rpi3` — both connected to
 as `root` (see `ansible.cfg`). `playbook.yml` targets `hosts: all`; all
 roles apply to both hosts except `roles/k3s`, which is gated to the
 `rpi4` group only, via `when: inventory_hostname in groups['rpi4']` on
 that role entry in `playbook.yml`'s `roles:` list — RPi3's more limited
-hardware runs no k3s node. Per-host values (hostname, WiFi static IP) live in
+hardware runs no k3s node — and `roles/node_exporter`, gated the same
+way to the `rpi3` group only. Per-host values (hostname, WiFi static IP) live in
 `group_vars/rpi4/` and `group_vars/rpi3/`; WiFi SSID/PSK are the same
 real network for both boards, so they live in `group_vars/all/`
-instead. _Last updated: 2026-08-20._
+instead. _Last updated: 2026-08-22._
 
 ## Commands
 
@@ -80,7 +83,12 @@ There is no test suite; correctness is validated via syntax-check + ansible-lint
      point `/etc/resolv.conf` at it
   7. `roles/wireguard` — install WireGuard, generate keys idempotently (uses
      `creates:` guards)
-  8. `roles/k3s` — install/upgrade k3s to the version pinned by
+  8. `roles/node_exporter` — install/configure `prometheus-node-exporter`,
+     exposing host metrics on `node_exporter_listen_address` (default
+     `0.0.0.0:9100`) for the separately managed RPi4/Flux Prometheus to
+     scrape (RPi3 only — gated via `when:` in `playbook.yml`; see
+     README.md's "Monitoring" section)
+  9. `roles/k3s` — install/upgrade k3s to the version pinned by
      `k3s_version` in `playbook.yml`, using
      `roles/k3s/templates/k3s-config.yaml.j2` (RPi4 only — gated via
      `when:` in `playbook.yml`)

--- a/README.md
+++ b/README.md
@@ -271,6 +271,25 @@ From then on, entering this directory exports
 prompting — no `ANSIBLE_PLAYBOOK` override needed — subject to however
 your password manager caches its own unlock.
 
+## Monitoring
+
+RPi3 runs
+[Prometheus Node Exporter](https://github.com/prometheus/node_exporter) via the
+`node_exporter` Ansible role, exposing host metrics (CPU, load, memory,
+filesystem, disk I/O, network, and a handful of systemd unit statuses)
+at `http://<rpi3-address>:9100/metrics`. The role only installs and runs
+the exporter; it does not itself deploy Prometheus or Grafana. Scraping
+is owned by the Prometheus instance already running on RPi4 (managed
+separately through Flux) — registering RPi3 as a scrape target and any
+Grafana dashboard work happen there, not in this repository. Port 9100
+should stay private to the home LAN.
+
+To validate the exporter is up after a run targeting RPi3:
+
+```sh
+curl -fsS http://<rpi3-address>:9100/metrics | head
+```
+
 ## Serial console connection
 
 To establish a serial console connection, connect the USB-to-TTL cable

--- a/playbook.yml
+++ b/playbook.yml
@@ -15,5 +15,7 @@
     - role: wireless
     - role: dns_resolver
     - role: wireguard
+    - role: node_exporter
+      when: inventory_hostname in groups['rpi3']
     - role: k3s
       when: inventory_hostname in groups['rpi4']

--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+node_exporter_listen_address: "0.0.0.0:9100"
+
+node_exporter_collectors:
+  - --collector.systemd
+  - --collector.systemd.unit-include=^(ssh|unbound|wg-quick@wg0|systemd-zram-setup@zram0)\.service$
+  - --collector.textfile.directory=/var/lib/prometheus/node-exporter
+  - --no-collector.btrfs
+  - --no-collector.infiniband
+  - --no-collector.ipvs
+  - --no-collector.nfs
+  - --no-collector.nfsd
+  - --no-collector.zfs

--- a/roles/node_exporter/handlers/main.yml
+++ b/roles/node_exporter/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+#
+# Handlers for node_exporter.
+#
+
+- name: Restart Node Exporter.
+  become: true
+  ansible.builtin.service:
+    name: prometheus-node-exporter
+    state: restarted

--- a/roles/node_exporter/meta/main.yml
+++ b/roles/node_exporter/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/roles/node_exporter/tasks/main.yml
+++ b/roles/node_exporter/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+#
+# Install and configure Prometheus Node Exporter.
+#
+# Exposes host metrics on node_exporter_listen_address for a separately
+# managed Prometheus (RPi4/Flux) to scrape. See README.md for the scrape
+# endpoint and validation command.
+#
+
+- name: Update apt cache if needed.
+  become: true
+  ansible.builtin.apt:
+    cache_valid_time: 3600
+    update_cache: true
+
+- name: Install Node Exporter if needed.
+  become: true
+  ansible.builtin.apt:
+    name: prometheus-node-exporter
+    state: present
+
+- name: Create Node Exporter textfile collector directory.
+  become: true
+  ansible.builtin.file:
+    path: /var/lib/prometheus/node-exporter
+    state: directory
+    owner: prometheus
+    group: prometheus
+    mode: "0755"
+
+- name: Configure Node Exporter arguments.
+  become: true
+  ansible.builtin.template:
+    src: prometheus-node-exporter.j2
+    dest: /etc/default/prometheus-node-exporter
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart Node Exporter.
+
+- name: Enable and start Node Exporter.
+  become: true
+  ansible.builtin.service:
+    name: prometheus-node-exporter
+    enabled: true
+    state: started

--- a/roles/node_exporter/templates/prometheus-node-exporter.j2
+++ b/roles/node_exporter/templates/prometheus-node-exporter.j2
@@ -1,0 +1,1 @@
+ARGS="--web.listen-address={{ node_exporter_listen_address }} {{ node_exporter_collectors | join(' ') }}"


### PR DESCRIPTION
## Summary

- Adds a `node_exporter` Ansible role, gated to the `rpi3` inventory group, installing and configuring `prometheus-node-exporter` so RPi4's Flux-managed Prometheus can scrape RPi3 host metrics on port 9100.
- Reviewed against the actual Debian bookworm `prometheus-node-exporter` package sources (`debian/service`, `debian/default`, `debian/postinst`) to confirm the package name, `/etc/default/prometheus-node-exporter` `ARGS` variable, and `prometheus:prometheus` ownership are correct.
- Aligned the role with this repo's existing conventions: added the missing `meta/main.yml`, trailing-period task/handler names with purpose comment headers, the repo's two-step apt cache-update pattern, consistent `become: true` placement, and removed an unused `node_exporter_enabled` variable (redundant with the group-level `when:` gate already used the same way as `roles/k3s`).
- Documents the exporter's port/endpoint/validation command in `README.md` (new "Monitoring" section) and updates `CLAUDE.md`'s role list.

Implements #55, intentionally excluding its "Improvements / additional metrics" section (thermal, Wi-Fi signal, pending-updates, etc.) as out of scope.

## Test plan

- [x] `make check` passes (yamllint + syntax-check + ansible-lint)
- [x] `markdownlint-cli2` passes on `README.md`/`CLAUDE.md`
- [x] `ansible-playbook --limit rpi3 playbook.yml` applied to the real RPi3 (run by repo owner)
- [x] `systemctl is-enabled prometheus-node-exporter && systemctl is-active prometheus-node-exporter` on RPi3
- [x] `curl -fsS http://<rpi3-address>:9100/metrics | head` from another LAN host