### PR TITLE
Remove wg-quick service from Prometheus config

### DIFF
--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -3,7 +3,7 @@ node_exporter_listen_address: "0.0.0.0:9100"
 
 node_exporter_collectors:
   - --collector.systemd
-  - --collector.systemd.unit-include=^(ssh|unbound|wg-quick@wg0|systemd-zram-setup@zram0)\.service$
+  - --collector.systemd.unit-include=^(ssh|unbound|systemd-zram-setup@zram0)\.service$
   - --collector.textfile.directory=/var/lib/prometheus/node-exporter
   - --no-collector.btrfs
   - --no-collector.infiniband


### PR DESCRIPTION
Update Prometheus Node Exporter to ignore the wg-quick service.